### PR TITLE
Checking for polyline in nurbs convert

### DIFF
--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -219,12 +219,20 @@ namespace BH.Engine.Rhinoceros
         {
             if (rCurve == null) return null;
 
+            if (rCurve.IsPolyline())
+            {
+                RHG.Polyline polyline;
+                rCurve.TryGetPolyline(out polyline);
+                return polyline.ToBHoM();
+            }
+
             if (rCurve.IsClosed && rCurve.IsEllipse())
             {
                 RHG.Ellipse ellipse = new RHG.Ellipse();
                 rCurve.TryGetEllipse(out ellipse);
                 return ellipse.ToBHoM();
             }
+
             IEnumerable<RHG.ControlPoint> rPoints = rCurve.Points;
             List<double> knots = rCurve.Knots.ToList();
             return new BHG.NurbsCurve


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #81 

<!-- Add short description of what has been fixed -->
Rhino interprets `Polyline`s as `NurbsCurve` sometimes, but the actual underlying object is a Polyline.
This pr adds a check in the conversion from Rhino nurbs to BHoM geometry.

### Test files
<!-- Link to test files to validate the proposed changes -->
Test file can be found at https://github.com/BHoM/BHoM_Engine/issues/870
You need to replace the ToPolyline component with the ToPolyline(Polyline) component

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->