### PR TITLE
Rhino_Toolkit #87 #86 #85 Conversion between new Solid Geometry representations 

### DIFF
--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -385,7 +385,7 @@ namespace BH.Engine.Rhinoceros
             if (brep.Surfaces.Count == 0) return null;
 
 
-            if (brep.IsSolid) return brep.ToBHoM(true);
+            if (brep.IsSolid) return brep.ToBHoMSolid();
         
 
             if (brep.IsPlanarSurface())
@@ -458,7 +458,7 @@ namespace BH.Engine.Rhinoceros
         /***************************************************/
 
 
-        private static BHG.ISolid ToBHoM(this RHG.Brep brep, bool isSolid)
+        private static BHG.ISolid ToBHoMSolid(this RHG.Brep brep)
         {
             RHG.Surface surface = brep.Surfaces.FirstOrDefault();
             switch (brep.Surfaces.Count)

--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -352,6 +352,12 @@ namespace BH.Engine.Rhinoceros
         {
             if (surface == null) return null;
 
+            if (surface.IsPlanar())
+            {
+                BHG.ICurve externalEdge = RHG.Curve.JoinCurves(surface.ToBrep().DuplicateNakedEdgeCurves(true, false)).FirstOrDefault().ToBHoM();
+                return new BHG.PlanarSurface { ExternalBoundary = externalEdge };
+            }
+                
             return surface.ToNurbsSurface().ToBHoM();
         }
 

--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -498,7 +498,7 @@ namespace BH.Engine.Rhinoceros
 
         public static BHG.Cone ToBHoM(this RHG.Cone cone)
         {
-            return new BHG.Cone { Centre = cone.BasePoint.ToBHoM(), Axis = cone.Axis.ToBHoM(), Radius = cone.Radius, Height = cone.Height };
+            return new BHG.Cone { Centre = cone.BasePoint.ToBHoM(), Axis = cone.Axis.ToBHoM()*-1.0, Radius = cone.Radius, Height = cone.Height };
         }
 
         /***************************************************/

--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -461,6 +461,9 @@ namespace BH.Engine.Rhinoceros
                     RHG.Sphere sphere;
                     if (surface.TryGetSphere(out sphere))
                         return sphere.ToBHoM();
+                    RHG.Torus torus;
+                    if (surface.TryGetTorus(out torus))
+                        return torus.ToBHoM();
                     break;
                 case 2:
                     RHG.Cone cone;

--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -444,6 +444,30 @@ namespace BH.Engine.Rhinoceros
             return face;
         }
 
+        /***************************************************/
+        /**** Public Methods  - Solids                  ****/
+        /***************************************************/
+
+        public static BHG.Sphere ToBHoM(this RHG.Sphere sphere)
+        {
+            return new BHG.Sphere { Centre = sphere.Center.ToBHoM(), Radius = sphere.Radius };
+        }
+
+        /***************************************************/
+
+        public static BHG.Cone ToBHoM(this RHG.Cone cone)
+        {
+            return new BHG.Cone { Centre = cone.BasePoint.ToBHoM(), Axis = cone.Axis.ToBHoM(), Radius = cone.Radius, Height = cone.Height };
+        }
+
+        /***************************************************/
+
+        public static BHG.Cylinder ToBHoM(this RHG.Cylinder cylinder)
+        {
+            BHG.Point centre = cylinder.Center.ToBHoM() + cylinder.Axis.ToBHoM() * cylinder.Height1;
+            return new BHG.Cylinder { Centre = centre, Axis = cylinder.Axis.ToBHoM(), Height = cylinder.TotalHeight, Radius = cylinder.CircleAt(0.0).Radius };
+        }
+
 
         /***************************************************/
         /**** Miscellanea                               ****/

--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -486,6 +486,13 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
+        public static BHG.Torus ToBHoM(this RHG.Torus torus)
+        {
+            return new BHG.Torus { Centre = torus.Plane.Origin.ToBHoM(), Axis = torus.Plane.ZAxis.ToBHoM(), RadiusMajor = torus.MajorRadius, RadiusMinor = torus.MinorRadius };
+        }
+
+        /***************************************************/
+
         public static BHG.Cone ToBHoM(this RHG.Cone cone)
         {
             return new BHG.Cone { Centre = cone.BasePoint.ToBHoM(), Axis = cone.Axis.ToBHoM(), Radius = cone.Radius, Height = cone.Height };

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -65,7 +65,7 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
-        public static RHG.Surface IToRhino(this BHG.ISurface surface)
+        public static RHG.GeometryBase IToRhino(this BHG.ISurface surface)
         {
             return (surface == default(BHG.ISurface)) ? null : Convert.ToRhino(surface as dynamic);
         }

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -372,6 +372,13 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
+        public static RHG.Brep ToRhino(this BHG.BoundaryRepresentation boundaryRepresentation)
+        {
+            return boundaryRepresentation.Surfaces.ToList().ToRhino();
+        }
+
+        /***************************************************/
+
         public static RHG.Brep ToRhino(this List<BHG.ISurface> surfaces)
         {
             RHG.Brep brep = new RHG.Brep();

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -461,6 +461,17 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
+        public static RHG.Torus ToRhino(this BHG.Torus torus)
+        {
+            if (torus == null) return default(RHG.Torus);
+
+            RHG.Plane plane = new RHG.Plane(torus.Centre.ToRhino(), torus.Axis.ToRhino());
+
+            return new RHG.Torus(plane, torus.RadiusMajor, torus.RadiusMinor);
+        }
+
+        /***************************************************/
+
         public static RHG.Cylinder ToRhino(this BHG.Cylinder cylinder)
         {
             if (cylinder == null) return default(RHG.Cylinder);

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -367,16 +367,24 @@ namespace BH.Engine.Rhinoceros
 
         public static RHG.Brep ToRhino(this BHG.PolySurface polySurface)
         {
+            return polySurface.Surfaces.ToRhino();
+        }
+
+        /***************************************************/
+
+        public static RHG.Brep ToRhino(this List<BHG.ISurface> surfaces)
+        {
             RHG.Brep brep = new RHG.Brep();
 
-            for (int i = 0; i < polySurface.Surfaces.Count; i++)
+            for (int i = 0; i < surfaces.Count; i++)
             {
-                RHG.GeometryBase geo = polySurface.Surfaces[i].IToRhino();
+                RHG.GeometryBase geo = surfaces[i].IToRhino();
                 if (geo is RHG.Surface) brep.AddSurface((RHG.Surface)geo);
                 else if (geo is RHG.Brep) brep.Append((RHG.Brep)geo);
+
             }
 
-            brep.JoinNakedEdges(BHG.Tolerance.Distance);
+            brep.JoinNakedEdges(0.001);
 
             return brep;
         }

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -465,6 +465,12 @@ namespace BH.Engine.Rhinoceros
         {
             if (torus == null) return default(RHG.Torus);
 
+            if (torus.RadiusMajor <= torus.RadiusMinor)
+            {
+                Reflection.Compute.RecordError("Major Radius less than or equal to Minor Radius. Conversion to Rhino Torus failed.");
+                return RHG.Torus.Unset;
+            }
+
             RHG.Plane plane = new RHG.Plane(torus.Centre.ToRhino(), torus.Axis.ToRhino());
 
             return new RHG.Torus(plane, torus.RadiusMajor, torus.RadiusMinor);

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -371,7 +371,9 @@ namespace BH.Engine.Rhinoceros
 
             for (int i = 0; i < polySurface.Surfaces.Count; i++)
             {
-                brep.AddSurface(polySurface.Surfaces[i].IToRhino());
+                RHG.GeometryBase geo = polySurface.Surfaces[i].IToRhino();
+                if (geo is RHG.Surface) brep.AddSurface((RHG.Surface)geo);
+                else if (geo is RHG.Brep) brep.Append((RHG.Brep)geo);
             }
 
             return brep;

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -449,6 +449,54 @@ namespace BH.Engine.Rhinoceros
 
 
         /***************************************************/
+        /**** Public Methods  - Solids                  ****/
+        /***************************************************/
+
+        public static RHG.Sphere ToRhino(this BHG.Sphere sphere)
+        {
+            if (sphere == null) return default(RHG.Sphere);
+
+            return new RHG.Sphere(sphere.Centre.ToRhino(), sphere.Radius);
+        }
+
+        /***************************************************/
+
+        public static RHG.Cylinder ToRhino(this BHG.Cylinder cylinder)
+        {
+            if (cylinder == null) return default(RHG.Cylinder);
+
+            RHG.Plane plane = new RHG.Plane(cylinder.Centre.ToRhino(), cylinder.Axis.ToRhino());
+            RHG.Circle circle = new RHG.Circle(plane, cylinder.Radius);
+
+            return new RHG.Cylinder(circle,cylinder.Height);
+        }
+
+        /***************************************************/
+
+        public static RHG.Cone ToRhino(this BHG.Cone cone)
+        {
+            if (cone == null) return default(RHG.Cone);
+
+            RHG.Plane plane = new RHG.Plane(cone.Centre.ToRhino(), cone.Axis.ToRhino());
+            
+            return new RHG.Cone(plane, cone.Height, cone.Radius);
+        }
+
+        /***************************************************/
+
+        public static RHG.Box ToRhino(this BHG.Cuboid cuboid)
+        {
+            if (cuboid == null) return default(RHG.Box);
+
+            RHG.Interval ix = new RHG.Interval((cuboid.Length / -2.0), (cuboid.Length / 2.0));
+            RHG.Interval iy = new RHG.Interval((cuboid.Depth / -2.0), (cuboid.Depth / 2.0));
+            RHG.Interval iz = new RHG.Interval((cuboid.Height / -2.0), (cuboid.Height / 2.0));
+
+            return new RHG.Box(cuboid.CoordinateSystem.ToRhino(),ix,iy,iz);
+        }
+
+
+        /***************************************************/
         /**** Miscellanea                               ****/
         /***************************************************/
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -391,7 +391,7 @@ namespace BH.Engine.Rhinoceros
 
             }
 
-            brep.JoinNakedEdges(0.001);
+            brep.JoinNakedEdges(BHG.Tolerance.Distance);
 
             return brep;
         }

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -376,6 +376,8 @@ namespace BH.Engine.Rhinoceros
                 else if (geo is RHG.Brep) brep.Append((RHG.Brep)geo);
             }
 
+            brep.JoinNakedEdges(BHG.Tolerance.Distance);
+
             return brep;
         }
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -388,9 +388,7 @@ namespace BH.Engine.Rhinoceros
                 RHG.GeometryBase geo = surfaces[i].IToRhino();
                 if (geo is RHG.Surface) brep.AddSurface((RHG.Surface)geo);
                 else if (geo is RHG.Brep) brep.Append((RHG.Brep)geo);
-
             }
-
             brep.JoinNakedEdges(BHG.Tolerance.Distance);
 
             return brep;
@@ -494,7 +492,8 @@ namespace BH.Engine.Rhinoceros
         {
             if (cone == null) return default(RHG.Cone);
 
-            RHG.Plane plane = new RHG.Plane(cone.Centre.ToRhino(), cone.Axis.ToRhino());
+            BHG.Vector axis = cone.Axis * -1.0;
+            RHG.Plane plane = new RHG.Plane((cone.Centre + cone.Axis*cone.Height).ToRhino(), axis.ToRhino());
             
             return new RHG.Cone(plane, cone.Height, cone.Radius);
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
This PR follows the development in the Geometry oM in the now merged PR here https://github.com/BHoM/BHoM/pull/456

This is to be tested in conjunction with https://github.com/BHoM/Grasshopper_Toolkit/pull/346

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #87 
Closes #86 
Closes #85 

<!-- Add short description of what has been fixed -->
Initial implementation of Rhino conversion `.ToRhino` and `.ToBHoM` for primative solids and the new BHoM Solid Boundary Representation.
For non-primative solids, functionality is still limited to planar surface representations.

### Test files
<!-- Link to test files to validate the proposed changes -->

[Test file for new Solid Object Converts](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FRhinoceros_Toolkit%2FRhinoceros_Toolkit-Issue86-87-SolidConverts&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


[Test file for PolySurface to Brep fix](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FRhinoceros_Toolkit%2FRhinoceros_Toolkit-Issue85-PolySurface%20to%20Rhino%2EBRep%20Fail)

