### PR TITLE
Adding convert for Basis

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -111,6 +111,15 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
+        public static RHG.Plane ToRhino(this BHG.Basis basis)
+        {
+            if (basis == null) return default(RHG.Plane);
+
+            return new RHG.Plane(RHG.Point3d.Unset, basis.X.ToRhino(), basis.Y.ToRhino());
+        }
+
+        /***************************************************/
+
         public static RHG.Quaternion ToRhino(this BHG.Quaternion quartenion)
         {
             return (quartenion == null) ? default(RHG.Quaternion) : new RHG.Quaternion(quartenion.X, quartenion.Y, quartenion.Z, quartenion.W);

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -111,15 +111,6 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
-        public static RHG.Plane ToRhino(this BHG.Basis basis)
-        {
-            if (basis == null) return default(RHG.Plane);
-
-            return new RHG.Plane(RHG.Point3d.Unset, basis.X.ToRhino(), basis.Y.ToRhino());
-        }
-
-        /***************************************************/
-
         public static RHG.Quaternion ToRhino(this BHG.Quaternion quartenion)
         {
             return (quartenion == null) ? default(RHG.Quaternion) : new RHG.Quaternion(quartenion.X, quartenion.Y, quartenion.Z, quartenion.W);

--- a/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
+++ b/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
@@ -41,7 +41,8 @@ namespace BH.Engine.Rhinoceros
                      && type != typeof(Loft)
                      && type != typeof(PolySurface)
                      && type != typeof(CompositeGeometry)
-                     && type != typeof(Quaternion));
+                     && type != typeof(Quaternion)
+                     && type != typeof(Basis));
             else
                 return false;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/481
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #92 

<!-- Add short description of what has been fixed -->

~~Adding convert for Basis. Current creates a rhino plane with a unset origin point. Could evaluate if this should be changed to the global origin. For now I believe it to be better to not set it, as that will imply incorrect information.~~

Adding basis to non-equivalent rhino types for when converting FROM BHoM. Rhino plane can still be used as input for methods wanting a basis.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Rhinoceros_Toolkit/Rhino_Tookit-Issue92-BasisConvert/Basis%20convert.gh?csf=1&e=RNSjt5
