### PR TITLE
Issue 98 - Convert.ToRhino(PanelPlanar) breaks on null

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -318,7 +318,6 @@ namespace BH.Engine.Rhinoceros
                 return null;
 
             RHG.Curve externalCurve = planarSurface.ExternalBoundary.IToRhino();
-
             if (externalCurve == null || !externalCurve.IsPlanar())
                 return null;
 
@@ -335,6 +334,9 @@ namespace BH.Engine.Rhinoceros
             rhCurves.Add(externalCurve);
 
             RHG.Brep[] rhSurfaces = RHG.Brep.CreatePlanarBreps(rhCurves);
+            if (rhSurfaces == null)
+                return null;
+
             if (rhSurfaces.Length > 1)
             {
                 //If more than one surface is extracted, try boolean difference of the curves to generate the geometry
@@ -342,12 +344,13 @@ namespace BH.Engine.Rhinoceros
                 inner.RemoveAt(inner.Count - 1);
 
                 RHG.Curve[] difference = RHG.Curve.CreateBooleanDifference(externalCurve, inner);
-
                 //Internal and external edges fully overlap -> 0 edges -> empty Brep
-                if (difference.Length == 0)
-                    return new RHG.Brep();
+                if (difference == null || difference.Length == 0)
+                    return null;
 
                 RHG.Brep[] rhSurfacesFromDifference = RHG.Brep.CreatePlanarBreps(difference);
+                if (rhSurfacesFromDifference == null)
+                    return null;
 
                 if (rhSurfacesFromDifference.Length > 1)
                 {
@@ -356,7 +359,9 @@ namespace BH.Engine.Rhinoceros
                 }
                 else if(rhSurfacesFromDifference.Length == 1)
                 {
-                    Reflection.Compute.RecordWarning("The internal edges overlap with the external. Boolean intersection has been preformed to try to get out the correct geometry. Topology might have changed for the surface obejct");
+                    Reflection.Compute.RecordWarning("The internal edges overlap with the external." +
+                        "Boolean intersection has been used to try to get out the correct geometry." +
+                        "Topology might have changed for the surface obejct");
                     return rhSurfacesFromDifference.FirstOrDefault();
                 }
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #98
<!-- Add short description of what has been fixed -->
The `ToRhino(PlanarSurface)` method returns now an exception if the rhinoceros operations of creating planar breps and performing boolean difference return `null`.
This pr is adding null checks to prevent that and returns `null` as the operation `ToRhino` cannot be performed.

At line 348, the code was returning an empty `Brep`. For consistency - the operation cannot be performed down to its end - it now returns null. Some interesting discussions [here](https://stackoverflow.com/questions/1969993/is-it-better-to-return-null-or-empty-collection) and [here](https://stackoverflow.com/questions/1626597/should-functions-return-null-or-an-empty-object).

### Test files
<!-- Link to test files to validate the proposed changes -->
There is no real test file, as I have not been able to reproduce the issue.
The original issue that @IsakNaslundBh was happening in a quite complex file that cannot be shared. 
If you want to replicate this, you can use [this file](https://burohappold.sharepoint.com/:f:/s/BHoM/EmkRIbft0CdLj1fQ696oTWwBw5zS-tI9k_bd5FNp4y7O-g?e=jNymch), debug it and manually set the `rhSurfaces`, `rhSurfacesFromDifference` variables to null with the Immediate Window.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->