### PR TITLE
Disconnected BH.oM.Geometry.PolyCurves return wrong results when converted to Rhino

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -222,9 +222,14 @@ namespace BH.Engine.Rhinoceros
             if (bPolyCurve == null)
                 return null;
 
-            if (!bPolyCurve.IsClosed())
+            // Check if bPolycurve is made of disconnected segments
+            IEnumerable<BHG.Point> endpoints = bPolyCurve.Curves.Select(x => x.IStartPoint());
+            endpoints = endpoints.Concat(bPolyCurve.Curves.Select(x => x.IEndPoint()));
+            endpoints = endpoints.ToList().CullDuplicates();
+            bool isDisconnected = endpoints.Count() != bPolyCurve.DiscontinuityPoints().Count;
+
+            if (isDisconnected)
             {
-                Engine.Reflection.Compute.RecordError("Cannot convert a list of disconnected curves to a Rhino.Geometry.PolyCurve");
                 return null;
             }
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -222,19 +222,15 @@ namespace BH.Engine.Rhinoceros
             if (bPolyCurve == null)
                 return null;
 
+            IEnumerable<RHG.Curve> parts = bPolyCurve.Curves.Select(x => x.IToRhino());
+            
             // Check if bPolycurve is made of disconnected segments
-            IEnumerable<BHG.Point> endpoints = bPolyCurve.Curves.Select(x => x.IStartPoint());
-            endpoints = endpoints.Concat(bPolyCurve.Curves.Select(x => x.IEndPoint()));
-            endpoints = endpoints.ToList().CullDuplicates();
-            bool isDisconnected = endpoints.Count() != bPolyCurve.DiscontinuityPoints().Count;
-
-            if (isDisconnected)
-            {
+            if (RHG.Curve.JoinCurves(parts).Length > 1)
                 return null;
-            }
 
             RHG.PolyCurve rPolycurve = new RHG.PolyCurve();
-            bPolyCurve.Curves.ForEach(curve => rPolycurve.Append(curve.IToRhino()));
+            foreach (RHG.Curve curve in parts)
+                rPolycurve.Append(curve);
             return rPolycurve;
         }
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -219,7 +219,14 @@ namespace BH.Engine.Rhinoceros
 
         public static RHG.PolyCurve ToRhino(this BHG.PolyCurve bPolyCurve)
         {
-            if (bPolyCurve == null) return null;
+            if (bPolyCurve == null)
+                return null;
+
+            if (!bPolyCurve.IsClosed())
+            {
+                Engine.Reflection.Compute.RecordError("Cannot convert a list of disconnected curves to a Rhino.Geometry.PolyCurve");
+                return null;
+            }
 
             RHG.PolyCurve rPolycurve = new RHG.PolyCurve();
             bPolyCurve.Curves.ForEach(curve => rPolycurve.Append(curve.IToRhino()));


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #113 

<!-- Add short description of what has been fixed -->
### Test files
<!-- Link to test files to validate the proposed changes -->
You can use the test file in https://github.com/BHoM/Rhinoceros_Toolkit/issues/113

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Engine.Rhinoceros.ToRhino(PolyCurve polycurve)` now returns `null` if the input curve is made of disconnected segments.
