### PR TITLE
Create converts for trimmed surfaces

### DIFF
--- a/Rhinoceros_Engine/Convert/ToBHoM.cs
+++ b/Rhinoceros_Engine/Convert/ToBHoM.cs
@@ -245,7 +245,7 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
-        public static BHG.ICurve ToBHoM(this RHG.Curve rCurve)
+        public static BHG.ICurve ToBHoM(this RHG.Curve rCurve, bool isNurbsConvert = false)
         {
             if (rCurve == null) return null;
 
@@ -254,7 +254,7 @@ namespace BH.Engine.Rhinoceros
             {
                 return new BHG.Line { Start = rCurve.PointAtStart.ToBHoM(), End = rCurve.PointAtEnd.ToBHoM(), Infinite = false };
             }
-            if (rCurve.IsCircle())
+            if (rCurve.IsCircle() && !isNurbsConvert)
             {
                 RHG.Circle circle = new RHG.Circle();
                 rCurve.TryGetCircle(out circle);
@@ -348,16 +348,60 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
+        public static BHG.ISurface ToBHoM(this RHG.BrepFace face)
+        {
+            if (face == null)
+                return null;
+            
+            RHG.Surface rhSurf = face.UnderlyingSurface();
+            if (face.IsPlanar())
+            {
+                BHG.PlanarSurface bhs = rhSurf.ToBHoM() as BHG.PlanarSurface;
+                foreach (RHG.BrepLoop loop in face.Loops)
+                {
+                    if (loop.LoopType == RHG.BrepLoopType.Inner)
+                        bhs.InternalBoundaries.Add(new BHG.PolyCurve { Curves = loop.Trims.Select(x => rhSurf.Pushup(x, BHG.Tolerance.Distance).ToBHoM()).ToList() });
+                    else if (loop.LoopType == RHG.BrepLoopType.Outer)
+                        bhs.ExternalBoundary = new BHG.PolyCurve { Curves = loop.Trims.Select(x => rhSurf.Pushup(x, BHG.Tolerance.Distance).ToBHoM()).ToList() };
+                }
+
+                return bhs;
+            }
+            else
+            {
+                BHG.NurbsSurface bhs = rhSurf.ToNurbsSurface().ToBHoM();
+
+                foreach (RHG.BrepLoop loop in face.Loops)
+                {
+                    if (loop.LoopType == RHG.BrepLoopType.Outer)
+                    {
+                        bhs.ExternalBoundaries3d.Add(new BHG.PolyCurve { Curves = loop.Trims.Select(x => rhSurf.Pushup(x, BHG.Tolerance.Distance).ToBHoM(true)).ToList() });
+                        bhs.ExternalBoundaries2d.Add(new BHG.PolyCurve { Curves = loop.Trims.Select(x => x.ToBHoM(true)).ToList() });
+                    }
+                    else
+                    {
+                        bhs.InternalBoundaries3d.Add(new BHG.PolyCurve { Curves = loop.Trims.Select(x => rhSurf.Pushup(x, BHG.Tolerance.Distance).ToBHoM(true)).ToList() });
+                        bhs.InternalBoundaries2d.Add(new BHG.PolyCurve { Curves = loop.Trims.Select(x => x.ToBHoM(true)).ToList() });
+                    }
+                }
+
+                return bhs;
+            }
+        }
+
+        /***************************************************/
+
         public static BHG.ISurface ToBHoM(this RHG.Surface surface)
         {
-            if (surface == null) return null;
+            if (surface == null)
+                return null;
 
             if (surface.IsPlanar())
             {
                 BHG.ICurve externalEdge = RHG.Curve.JoinCurves(surface.ToBrep().DuplicateNakedEdgeCurves(true, false)).FirstOrDefault().ToBHoM();
                 return new BHG.PlanarSurface { ExternalBoundary = externalEdge };
             }
-                
+
             return surface.ToNurbsSurface().ToBHoM();
         }
 
@@ -367,27 +411,32 @@ namespace BH.Engine.Rhinoceros
         {
             if (surface == null) return null;
 
-            return new BHG.NurbsSurface
+            BHG.NurbsSurface bhs = new BHG.NurbsSurface
             {
                 ControlPoints = surface.Points.Select(x => x.Location.ToBHoM()).ToList(),
                 Weights = surface.Points.Select(x => x.Weight).ToList(),
                 UKnots = surface.KnotsU.ToList(),
-                VKnots = surface.KnotsV.ToList()
+                VKnots = surface.KnotsV.ToList(),
+                UDegree = surface.Degree(0),
+                VDegree = surface.Degree(1)
             };
+
+            return bhs;
         }
 
         /***************************************************/
 
         public static BHG.IGeometry ToBHoM(this RHG.Brep brep)
         {
-            if (brep == null) return null;
+            if (brep == null)
+                return null;
 
-            if (brep.Surfaces.Count == 0) return null;
-
-
-            if (brep.IsSolid) return brep.ToBHoMSolid();
+            if (brep.Surfaces.Count == 0)
+                return null;
+            
+            if (brep.IsSolid)
+                return brep.ToBHoMSolid();
         
-
             if (brep.IsPlanarSurface())
             {
                 BHG.ICurve externalEdge = RHG.Curve.JoinCurves(brep.DuplicateNakedEdgeCurves(true, false)).FirstOrDefault().ToBHoM();
@@ -396,7 +445,7 @@ namespace BH.Engine.Rhinoceros
             }
 
             // Default case - return open Polysurface
-            return new BHG.PolySurface() { Surfaces = brep.Surfaces.Select(s => s.ToBHoM()).ToList() };
+            return new BHG.PolySurface() { Surfaces = brep.Faces.Select(s => s.ToBHoM()).ToList() };
         }
 
         /***************************************************/
@@ -483,7 +532,7 @@ namespace BH.Engine.Rhinoceros
                     break;
             }
 
-            return new BHG.BoundaryRepresentation(brep.Surfaces.Select(s => s.ToBHoM()).ToList());
+            return new BHG.BoundaryRepresentation(brep.Faces.Select(s => s.ToBHoM()).ToList());
         }
 
         /***************************************************/

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -323,7 +323,7 @@ namespace BH.Engine.Rhinoceros
             List<RHG.Curve> rhCurves = new List<RHG.Curve>();
             if (planarSurface.InternalBoundaries != null)
             {
-                rhCurves.AddRange(planarSurface.InternalBoundaries.Select(c => c.IToRhino()).Where(c => c.IsPlanar()).ToList());
+                rhCurves.AddRange(planarSurface.InternalBoundaries.Select(c => c.IToRhino()).Where(c => c.IsPlanar(BHG.Tolerance.Distance)).ToList());
                 if (rhCurves.Count < planarSurface.InternalBoundaries.Count)
                 {
                     int skipped = planarSurface.InternalBoundaries.Count - rhCurves.Count;

--- a/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
+++ b/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Rhinoceros
                 return (type != typeof(Extrusion)
                      && type != typeof(Pipe)
                      && type != typeof(Loft)
-                     && type != typeof(PolySurface)
+                     //&& type != typeof(PolySurface)
                      && type != typeof(CompositeGeometry)
                      && type != typeof(Quaternion)
                      && type != typeof(Basis));


### PR DESCRIPTION
### !!! PLEASE DO NOT MERGE !!! ###

### NOTE: Depends on 
[#603](https://github.com/BHoM/BHoM/pull/603)
[#1298](https://github.com/BHoM/BHoM_Engine/pull/1298)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #119 

<!-- Add short description of what has been fixed -->


### Test files<!-- Link to test files to validate the proposed changes -->
Test file is located on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue425%2DCreationOfTrimmedNurbsSurfaceDefinition). To run it, please switch to the branches related to the following PRs:
- [#603 ](https://github.com/BHoM/BHoM/pull/603)
- [#1298](https://github.com/BHoM/BHoM_Engine/pull/1298)
- [#120](https://github.com/BHoM/Rhinoceros_Toolkit/pull/120)
- [#431](https://github.com/BHoM/Grasshopper_Toolkit/pull/431)

The error in the test file is caused by the bug in Cone convert logged [here](https://github.com/BHoM/Rhinoceros_Toolkit/issues/121).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Converts for trimmed nurbs surfaces have been added following changes in the `NurbsSurface` definition.

### Additional comments
Please see [#603](https://github.com/BHoM/BHoM/pull/603).

There is still a few hacky workarounds and boilerplate/overhead, to be polished once the architecture is agreed in BHoM.
<!-- As required -->