### PR TITLE
Create converts for trimmed surfaces

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -27,6 +27,7 @@ using RHG = Rhino.Geometry;
 using BHG = BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.oM.Reflection.Attributes;
+using BH.Engine.Reflection;
 
 namespace BH.Engine.Rhinoceros
 {
@@ -283,29 +284,6 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
-        public static RHG.NurbsSurface ToRhino(this BHG.NurbsSurface surface)
-        {
-            if (surface == null)
-                return null;
-
-            List<int> uvCount = surface.UVCount();
-            List<int> degrees = surface.Degrees();
-            List<BHG.Point> points = surface.ControlPoints;
-            List<double> weights = surface.Weights;
-            RHG.NurbsSurface rhSurface = RHG.NurbsSurface.Create(3, true, degrees[0] + 1, degrees[1] + 1, uvCount[0], uvCount[1]);
-            for (int i = 0; i < rhSurface.KnotsU.Count; i++)
-                rhSurface.KnotsU[i] = surface.UKnots[i];
-            for (int i = 0; i < rhSurface.KnotsV.Count; i++)
-                rhSurface.KnotsV[i] = surface.VKnots[i];
-            for (int i = 0; i < uvCount[0]; i++)
-                for (int j = 0; j < uvCount[1]; j++)
-                    rhSurface.Points.SetControlPoint(i, j, new RHG.ControlPoint(points[j + (uvCount[1] * i)].ToRhino(), weights[j + (uvCount[1] * i)]));
-
-            return rhSurface.IsValid ? rhSurface : null;
-        }
-
-        /***************************************************/
-
         public static RHG.Brep ToRhino(this BHG.Pipe pipe)
         {
             if (pipe == null)
@@ -339,13 +317,13 @@ namespace BH.Engine.Rhinoceros
                 return null;
 
             RHG.Curve externalCurve = planarSurface.ExternalBoundary.IToRhino();
-            if (externalCurve == null || !externalCurve.IsPlanar())
+            if (externalCurve == null || !externalCurve.IsPlanar(BHG.Tolerance.Distance))
                 return null;
 
             List<RHG.Curve> rhCurves = new List<RHG.Curve>();
             if (planarSurface.InternalBoundaries != null)
             {
-                rhCurves.AddRange(planarSurface.InternalBoundaries.Select(c => c.IToRhino()).Where(c => c.IsPlanar()).ToList());
+                rhCurves.AddRange(planarSurface.InternalBoundaries.Select(c => c.IToRhino()).Where(c => c.IsPlanar(BHG.Tolerance.Distance)).ToList());
                 if (rhCurves.Count < planarSurface.InternalBoundaries.Count)
                 {
                     int skipped = planarSurface.InternalBoundaries.Count - rhCurves.Count;
@@ -387,6 +365,48 @@ namespace BH.Engine.Rhinoceros
                 }
             }
             return rhSurfaces.FirstOrDefault();
+        }
+
+        /***************************************************/
+
+        public static RHG.GeometryBase ToRhino(this BHG.NurbsSurface surface)
+        {
+            if (surface == null)
+                return null;
+
+            List<int> uvCount = surface.UVCount();
+            RHG.NurbsSurface rhSurface = RHG.NurbsSurface.Create(3, true, surface.UDegree + 1, surface.VDegree + 1, uvCount[0], uvCount[1]);
+            for (int i = 0; i < rhSurface.KnotsU.Count; i++)
+                rhSurface.KnotsU[i] = surface.UKnots[i];
+            for (int i = 0; i < rhSurface.KnotsV.Count; i++)
+                rhSurface.KnotsV[i] = surface.VKnots[i];
+            for (int i = 0; i < uvCount[0]; i++)
+                for (int j = 0; j < uvCount[1]; j++)
+                    rhSurface.Points.SetControlPoint(i, j, new RHG.ControlPoint(surface.ControlPoints[j + (uvCount[1] * i)].ToRhino(), surface.Weights[j + (uvCount[1] * i)]));
+
+            if (!rhSurface.IsValid)
+                return null;
+
+            if (surface.ExternalBoundaries3d.Count == 0)
+                return rhSurface;
+            else
+            {
+                RHG.Brep brep = new RHG.Brep();
+                int srf = brep.AddSurface(rhSurface);
+                RHG.BrepFace face = brep.Faces.Add(srf);
+                
+                for (int i = 0; i < surface.ExternalBoundaries3d.Count; i++)
+                {
+                    brep.AddBrepOutline(face, surface.ExternalBoundaries3d[i], surface.ExternalBoundaries2d[i], RHG.BrepLoopType.Outer);
+                }
+
+                for (int i = 0; i < surface.InternalBoundaries3d.Count; i++)
+                {
+                    brep.AddBrepOutline(face, surface.InternalBoundaries3d[i], surface.InternalBoundaries2d[i], RHG.BrepLoopType.Inner);
+                }
+
+                return brep.IsValid ? brep : null;
+            }
         }
 
         /***************************************************/
@@ -547,6 +567,130 @@ namespace BH.Engine.Rhinoceros
             if (geometries == null) return new List<object>();
 
             return geometries.Elements.Select(x => x.IToRhino()).ToList();
+        }
+
+
+        /***************************************************/
+        /**** Private methods                           ****/
+        /***************************************************/
+
+        private static void AddBrepOutline(this RHG.Brep brep, RHG.BrepFace face, BHG.ICurve outline3d, BHG.ICurve outline2d, RHG.BrepLoopType loopType)
+        {
+            RHG.BrepLoop loop = brep.Loops.Add(loopType, face);
+            List<BHG.ICurve> subParts3d = outline3d.ISubParts().ToList();
+            List<BHG.ICurve> subParts2d = outline2d.ISubParts().ToList();
+
+            for (int i = 0; i < subParts3d.Count; i++)
+            {
+                BHG.ICurve bhc = subParts3d[i];
+                RHG.Curve rhc = bhc.IToRhino();
+
+                int startId = brep.AddVertex(rhc.PointAtStart);
+                int endId = brep.AddVertex(rhc.PointAtEnd);
+
+                RHG.BrepTrim trim;
+                RHG.Curve rhc2d = subParts2d[i].IToRhino();
+                rhc2d.ChangeDimension(2);
+                int crv2d = brep.Curves2D.Add(rhc2d);
+                if (rhc.IsValid)
+                {
+                    bool rev3d = true;
+                    RHG.BrepEdge edge = null;
+                    foreach (RHG.BrepEdge e in brep.Edges)
+                    {
+                        if (e.StartVertex.VertexIndex == endId && e.EndVertex.VertexIndex == startId && rhc.IsSameEdge(e))
+                        {
+                            edge = e;
+                            break;
+                        }
+                    }
+
+                    if (edge == null)
+                    {
+                        int crv = brep.Curves3D.Add(rhc);
+                        edge = brep.Edges.Add(startId, endId, crv, BH.oM.Geometry.Tolerance.Distance);
+                        rev3d = false;
+                    }
+
+                    trim = brep.Trims.Add(edge, rev3d, loop, crv2d);
+                }
+                else
+                    trim = brep.Trims.AddSingularTrim(brep.Vertices[startId], loop, Rhino.Geometry.IsoStatus.None, crv2d);
+
+                trim.SetTolerances(BH.oM.Geometry.Tolerance.Distance, BH.oM.Geometry.Tolerance.Distance);
+
+                //TODO: In Rhino 6 this could be replaced with Surface.IsIsoParametric(Curve)
+                RHG.Point3d start = rhc2d.PointAtStart;
+                RHG.Point3d end = rhc2d.PointAtEnd;
+
+                if (rhc2d.IsLinear())
+                {
+                    if (Math.Abs(start.X - end.X) <= BH.oM.Geometry.Tolerance.Distance)
+                    {
+                        RHG.Interval domainU = brep.Surfaces[face.SurfaceIndex].Domain(0);
+                        if (Math.Abs(start.X - domainU.Min) <= BH.oM.Geometry.Tolerance.Distance)
+                            trim.IsoStatus = Rhino.Geometry.IsoStatus.West;
+                        else if (Math.Abs(start.X - domainU.Max) <= BH.oM.Geometry.Tolerance.Distance)
+                            trim.IsoStatus = RHG.IsoStatus.East;
+                        else
+                            trim.IsoStatus = RHG.IsoStatus.X;
+                    }
+                    else if (Math.Abs(start.Y - end.Y) <= BH.oM.Geometry.Tolerance.Distance)
+                    {
+                        RHG.Interval domainV = brep.Surfaces[face.SurfaceIndex].Domain(1);
+                        if (Math.Abs(start.Y - domainV.Min) <= BH.oM.Geometry.Tolerance.Distance)
+                            trim.IsoStatus = Rhino.Geometry.IsoStatus.South;
+                        else if (Math.Abs(start.Y - domainV.Max) <= BH.oM.Geometry.Tolerance.Distance)
+                            trim.IsoStatus = RHG.IsoStatus.North;
+                        else
+                            trim.IsoStatus = RHG.IsoStatus.Y;
+                    }
+                }
+            }
+        }
+
+        /***************************************************/
+        
+        private static int AddVertex(this RHG.Brep brep, RHG.Point3d point)
+        {
+            int id = -1;
+            for (int j = 0; j < brep.Vertices.Count; j++)
+            {
+                if (point.DistanceTo(brep.Vertices[j].Location) <= BHG.Tolerance.Distance)
+                {
+                    id = j;
+                    break;
+                }
+            }
+
+            if (id == -1)
+            {
+                brep.Vertices.Add(point, BHG.Tolerance.Distance);
+                id = brep.Vertices.Count - 1;
+            }
+
+            return id;
+        }
+
+        /***************************************************/
+        
+        private static bool IsSameEdge(this RHG.Curve curve, RHG.BrepEdge edge)
+        {
+            double tolerance = BHG.Tolerance.Distance;
+            RHG.Curve edgeCurve = edge.DuplicateCurve();
+            edgeCurve.Reverse();
+
+            RHG.BoundingBox bb1 = curve.GetBoundingBox(false);
+            RHG.BoundingBox bb2 = edgeCurve.GetBoundingBox(false);
+            if (bb1.Min.DistanceTo(bb2.Min) > tolerance || bb1.Max.DistanceTo(bb2.Max) > tolerance)
+                return false;
+
+            int frameCount = 100;
+            RHG.Point3d[] frames1, frames2;
+            curve.DivideByCount(frameCount, false, out frames1);
+            edgeCurve.DivideByCount(frameCount, false, out frames2);
+
+            return Enumerable.Range(0, frameCount - 1).All(i => frames1[i].DistanceTo(frames2[i]) <= tolerance);
         }
 
         /***************************************************/

--- a/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
+++ b/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Rhinoceros
                 return (type != typeof(Extrusion)
                      && type != typeof(Pipe)
                      && type != typeof(Loft)
-                     && type != typeof(PolySurface)
+                     //&& type != typeof(PolySurface)
                      && type != typeof(CompositeGeometry)
                      && type != typeof(Quaternion)
                      && type != typeof(Basis));


### PR DESCRIPTION
### NOTE: Depends on 
[#603](https://github.com/BHoM/BHoM/pull/603)
[#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #119 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test files are located on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue425%2DCreationOfTrimmedNurbsSurfaceDefinition). To run it, please switch to the branches related to the following PRs:
- [#603 ](https://github.com/BHoM/BHoM/pull/603)
- [#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)
- [#122](https://github.com/BHoM/Rhinoceros_Toolkit/pull/122)
- [#435](https://github.com/BHoM/Grasshopper_Toolkit/pull/435)
- [#435](https://github.com/BHoM/Revit_Toolkit/pull/435)
- [#183](https://github.com/BHoM/Dynamo_Toolkit/pull/183)

The error in Rhino -> BHoM -> Rhino convert error in the test file is caused by the bug in Cone convert logged [here](https://github.com/BHoM/Rhinoceros_Toolkit/issues/121).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Converts for trimmed nurbs surfaces have been added following changes in the `NurbsSurface` definition.

### Additional comments
Updated copy of #120.
Please see [#603](https://github.com/BHoM/BHoM/pull/603).

Actions to be taken after this PR gets merged:
- review [Conversion Table](https://github.com/BHoM/Rhinoceros_Toolkit/wiki/BHoM---Rhinoceros-conversion-table)