### PR TITLE
RenderMesh Compatibility in ToRhino

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -150,7 +150,7 @@ namespace BH.Engine.Rhinoceros
         
         /***************************************************/
 
-        public static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
+        private static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
         {
             if (point == null) return default(RHG.Point3d);
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -28,6 +28,7 @@ using BHG = BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.oM.Reflection.Attributes;
 using BH.Engine.Reflection;
+using System.Drawing;
 
 namespace BH.Engine.Rhinoceros
 {
@@ -491,6 +492,27 @@ namespace BH.Engine.Rhinoceros
                 return new RHG.MeshFace(rFace.A, rFace.B, rFace.C);
         }
 
+        /***************************************************/
+        /**** Public Methods  - Mesh                    ****/
+        /***************************************************/
+
+        public static RHG.Mesh ToRhino(this BH.oM.Graphics.RenderMesh mesh)
+        {
+            RHG.Mesh rMesh = ToRhino(new BHG.Mesh() { Vertices = mesh.Vertices.Select(x => x.Point).ToList(), Faces = mesh.Faces });
+
+            Color[] colors = mesh.Vertices.Select(x => x.Color).ToArray();
+            rMesh.VertexColors.SetColors(colors);
+            return rMesh;
+        }
+
+        /***************************************************/
+
+        public static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
+        {
+            if (point == null) return default(RHG.Point3d);
+
+            return new RHG.Point3d(point.Point.X, point.Point.Y, point.Point.Z);
+        }
 
         /***************************************************/
         /**** Public Methods  - Solids                  ****/

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -147,7 +147,15 @@ namespace BH.Engine.Rhinoceros
 
             return rhTrans;
         }
+        
+        /***************************************************/
 
+        public static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
+        {
+            if (point == null) return default(RHG.Point3d);
+
+            return new RHG.Point3d(point.Point.X, point.Point.Y, point.Point.Z);
+        }
 
         /***************************************************/
         /**** Public Methods  - Curves                  ****/
@@ -493,8 +501,6 @@ namespace BH.Engine.Rhinoceros
         }
 
         /***************************************************/
-        /**** Public Methods  - Mesh                    ****/
-        /***************************************************/
 
         public static RHG.Mesh ToRhino(this BH.oM.Graphics.RenderMesh mesh)
         {
@@ -503,15 +509,6 @@ namespace BH.Engine.Rhinoceros
             Color[] colors = mesh.Vertices.Select(x => x.Color).ToArray();
             rMesh.VertexColors.SetColors(colors);
             return rMesh;
-        }
-
-        /***************************************************/
-
-        public static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
-        {
-            if (point == null) return default(RHG.Point3d);
-
-            return new RHG.Point3d(point.Point.X, point.Point.Y, point.Point.Z);
         }
 
         /***************************************************/

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -504,8 +504,25 @@ namespace BH.Engine.Rhinoceros
 
         public static RHG.Mesh ToRhino(this BH.oM.Graphics.RenderMesh mesh)
         {
-            RHG.Mesh rMesh = ToRhino(new BHG.Mesh() { Vertices = mesh.Vertices.Select(x => x.Point).ToList(), Faces = mesh.Faces });
+            if (mesh == null) return null;
 
+            List<RHG.Point3d> rVertices = mesh.Vertices.Select(x => x.ToRhino()).ToList();
+            List<BHG.Face> faces = mesh.Faces;
+            List<RHG.MeshFace> rFaces = new List<RHG.MeshFace>();
+            for (int i = 0; i < faces.Count; i++)
+            {
+                if (faces[i].IsQuad())
+                {
+                    rFaces.Add(new RHG.MeshFace(faces[i].A, faces[i].B, faces[i].C, faces[i].D));
+                }
+                else
+                {
+                    rFaces.Add(new RHG.MeshFace(faces[i].A, faces[i].B, faces[i].C));
+                }
+            }
+            RHG.Mesh rMesh = new RHG.Mesh();
+            rMesh.Faces.AddFaces(rFaces);
+            rMesh.Vertices.AddVertices(rVertices);
             Color[] colors = mesh.Vertices.Select(x => x.Color).ToArray();
             rMesh.VertexColors.SetColors(colors);
             return rMesh;

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -724,8 +724,7 @@ namespace BH.Engine.Rhinoceros
 
         private static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
         {
-            if (point == null)
-                return default(RHG.Point3d);
+            if (point == null) return default(RHG.Point3d);
 
             return new RHG.Point3d(point.Point.X, point.Point.Y, point.Point.Z);
         }

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -147,15 +147,6 @@ namespace BH.Engine.Rhinoceros
 
             return rhTrans;
         }
-        
-        /***************************************************/
-
-        private static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
-        {
-            if (point == null) return default(RHG.Point3d);
-
-            return new RHG.Point3d(point.Point.X, point.Point.Y, point.Point.Z);
-        }
 
         /***************************************************/
         /**** Public Methods  - Curves                  ****/
@@ -730,5 +721,16 @@ namespace BH.Engine.Rhinoceros
         }
 
         /***************************************************/
+
+        private static RHG.Point3d ToRhino(this BH.oM.Graphics.Vertex point)
+        {
+            if (point == null)
+                return default(RHG.Point3d);
+
+            return new RHG.Point3d(point.Point.X, point.Point.Y, point.Point.Z);
+        }
+
+        /***************************************************/
+
     }
 }

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -45,6 +45,9 @@
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Graphics_oM">
+      <HintPath>..\..\BHoM\Graphics_oM\obj\Debug\Graphics_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Reflection_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
@@ -59,6 +62,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -45,8 +45,9 @@
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Graphics_oM">
-      <HintPath>..\..\BHoM\Graphics_oM\obj\Debug\Graphics_oM.dll</HintPath>
+    <Reference Include="Graphics_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Graphics_oM.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>

--- a/Rhinoceros_Test/Rhinoceros_Test.csproj
+++ b/Rhinoceros_Test/Rhinoceros_Test.csproj
@@ -73,7 +73,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Graphics_oM">
-      <HintPath>..\..\BHoM\Graphics_oM\obj\Debug\Graphics_oM.dll</HintPath>
+      <HintPath>..\..\BHoM\Build\Graphics_oM.dll</HintPath>
     </Reference>
     <Reference Include="RhinoCommon, Version=5.1.30000.16, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
       <HintPath>..\packages\RhinoCommon.5.12.50810.13095\lib\net35\RhinoCommon.dll</HintPath>

--- a/Rhinoceros_Test/Rhinoceros_Test.csproj
+++ b/Rhinoceros_Test/Rhinoceros_Test.csproj
@@ -72,6 +72,9 @@
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Graphics_oM">
+      <HintPath>..\..\BHoM\Graphics_oM\obj\Debug\Graphics_oM.dll</HintPath>
+    </Reference>
     <Reference Include="RhinoCommon, Version=5.1.30000.16, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
       <HintPath>..\packages\RhinoCommon.5.12.50810.13095\lib\net35\RhinoCommon.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

### Made in conjunction with
https://github.com/BHoM/Grasshopper_Toolkit/pull/443

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #123 
`RenderMesh` compatibility in the `ToRhino` method. 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EXM3ujoChKBJsySLflVn0HYBuptbbBs5t2rty6UNtaUWLg?e=wF8Ib8

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- added `ToRhino` for `RenderMesh`
- added `ToRhino` for `Vertex` (which are in a `RenderMesh`)

### Additional comments
<!-- As required -->