### PR TITLE
Fix misaligned definition of ControlPoint between Rhino6 and Rhino5

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -196,24 +196,15 @@ namespace BH.Engine.Rhinoceros
 
         public static RHG.NurbsCurve ToRhino(this BHG.NurbsCurve bCurve)
         {
-            if (bCurve == null) return null;
-
-            List<double> knots = bCurve.Knots;
-            List<double> weights = bCurve.Weights;
-            List<BHG.Point> ctrlPts = bCurve.ControlPoints;
-
-            RHG.NurbsCurve rCurve = new RHG.NurbsCurve(3, false, bCurve.Degree() + 1, ctrlPts.Count);
-
-            for (int i = 0; i < knots.Count; i++)
-                rCurve.Knots[i] = knots[i];
-
-            for (int i = 0; i < ctrlPts.Count; i++)
+            switch (Rhino.RhinoApp.Version.Major)
             {
-                BHG.Point pt = ctrlPts[i];
-                rCurve.Points.SetPoint(i, pt.X, pt.Y, pt.Z, weights[i]);
+                case 5:
+                    return ToRhino5(bCurve);
+                case 6:
+                    return ToRhino6(bCurve);
+                default:
+                    throw new NotImplementedException($"Rhino {Rhino.RhinoApp.Version.ToString()} version not supported.");
             }
-
-            return rCurve;
         }
 
         /***************************************************/

--- a/Rhinoceros_Engine/Convert/ToRhino5.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino5.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using RHG = Rhino.Geometry;
+using BHG = BH.oM.Geometry;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.Rhinoceros
+{
+    public static partial class Convert
+    {
+        public static RHG.NurbsCurve ToRhino5(this BHG.NurbsCurve bCurve)
+        {
+            if (bCurve == null) return null;
+
+            List<double> knots = bCurve.Knots;
+            List<double> weights = bCurve.Weights;
+            List<BHG.Point> ctrlPts = bCurve.ControlPoints;
+
+            RHG.NurbsCurve rCurve = new RHG.NurbsCurve(3, false, bCurve.Degree() + 1, ctrlPts.Count);
+
+            for (int i = 0; i < knots.Count; i++)
+                rCurve.Knots[i] = knots[i];
+
+            for (int i = 0; i < ctrlPts.Count; i++)
+            {
+                BHG.Point pt = ctrlPts[i];
+                rCurve.Points.SetPoint(i, pt.X, pt.Y, pt.Z, weights[i]);
+            }
+
+            return rCurve;
+        }
+    }
+}

--- a/Rhinoceros_Engine/Convert/ToRhino6.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino6.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using RHG = Rhino.Geometry;
+using BHG = BH.oM.Geometry;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.Rhinoceros
+{
+    public static partial class Convert
+    {
+        public static RHG.NurbsCurve ToRhino6(this BHG.NurbsCurve bCurve)
+        {
+            if (bCurve == null) return null;
+
+            List<double> knots = bCurve.Knots;
+            List<double> weights = bCurve.Weights;
+            List<BHG.Point> ctrlPts = bCurve.ControlPoints;
+
+            RHG.NurbsCurve rCurve = new RHG.NurbsCurve(3, false, bCurve.Degree() + 1, ctrlPts.Count);
+
+            for (int i = 0; i < knots.Count; i++)
+                rCurve.Knots[i] = knots[i];
+
+            for (int i = 0; i < ctrlPts.Count; i++)
+            {
+                BHG.Point pt = ctrlPts[i] * weights[i];
+                rCurve.Points.SetPoint(i, pt.X, pt.Y, pt.Z, weights[i]);
+            }
+
+            return rCurve;
+        }
+    }
+}

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -79,6 +79,8 @@
   <ItemGroup>
     <Compile Include="Convert\FromRhino.cs" />
     <Compile Include="Convert\ToRhino.cs" />
+    <Compile Include="Convert\ToRhino6.cs" />
+    <Compile Include="Convert\ToRhino5.cs" />
     <Compile Include="Create\Arc.cs" />
     <Compile Include="Create\ArcCurve.cs" />
     <Compile Include="Create\Circle.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Closes #137

<!-- Add short description of what has been fixed -->
As described in the issue, rhino changed its internal representation of a `ControlPoint`. This drove us to different results if we opened the same file, with the same grasshopper definition, in Rhino 5 or Rhino 6.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EY5NVt3M04xFm5O8ZWCPWY8Bme7MlFnCg_AbRjuFonR6Yw?e=xv3qGk

To check if this works, make sure that converting back and forth always returns the same object.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->