### PR TITLE
Fix crash on invalid mesh preview in Rhino

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -453,15 +453,24 @@ namespace BH.Engine.Rhinoceros
             List<RHG.Point3d> rVertices = mesh.Vertices.Select(x => x.ToRhino()).ToList();
             List<BHG.Face> faces = mesh.Faces;
             List<RHG.MeshFace> rFaces = new List<RHG.MeshFace>();
+            int nbVertices = rVertices.Count;
             for (int i = 0; i < faces.Count; i++)
             {
-                if (faces[i].IsQuad())
+                BHG.Face face = faces[i];
+                if (face.IsQuad())
                 {
-                    rFaces.Add(new RHG.MeshFace(faces[i].A, faces[i].B, faces[i].C, faces[i].D));
+
+                    if (face.A < nbVertices && face.B < nbVertices && face.C < nbVertices && face.D < nbVertices)
+                        rFaces.Add(new RHG.MeshFace(face.A, face.B, face.C, face.D));
+                    else
+                        Reflection.Compute.RecordWarning("Mesh face [" + face.A + ", " + face.B + ", " + face.C + ", " + face.D + "] could not be created due to corresponding vertices missing");
                 }
                 else
                 {
-                    rFaces.Add(new RHG.MeshFace(faces[i].A, faces[i].B, faces[i].C));
+                    if (face.A < nbVertices && face.B < nbVertices && face.C < nbVertices)
+                        rFaces.Add(new RHG.MeshFace(face.A, face.B, face.C));
+                    else
+                        Reflection.Compute.RecordWarning("Mesh face [" + face.A + ", " + face.B + ", " + face.C + "] could not be created due to corresponding vertices missing");
                 }
             }
             RHG.Mesh rMesh = new RHG.Mesh();


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #160

Faces are added to the Rhino mesh if the vertices exist (well, the index exists). Faces not added will trigger a warning:

![image](https://user-images.githubusercontent.com/16853390/81903798-dff29f80-95f4-11ea-859a-15847113b124.png)


### Test files
See issue for test file


### Additional comments
@epignatelli , I am on your turf here so I hope I don't collide with your current plans (doesn't look like I do given sprint minutes). If I do, feel free to put this on hold.  Also happy for you to use a different strategy to solve the issue if you feel this is creating side effects on the normal use of this toolkit.