### PR TITLE
BHoM => Rhino BRep convert tolerance bug fixed

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -395,7 +395,7 @@ namespace BH.Engine.Rhinoceros
                 {
                     brep.AddBrepTrim(face, trim, RHG.BrepLoopType.Inner);
                 }
-
+                
                 return brep.IsValid ? brep : null;
             }
         }
@@ -622,6 +622,8 @@ namespace BH.Engine.Rhinoceros
             List<BHG.ICurve> subParts3d = trim.Curve3d.ISubParts().ToList();
             List<BHG.ICurve> subParts2d = trim.Curve2d.ISubParts().ToList();
 
+            double rhinoTolerance = Query.DocumentTolerance();
+
             for (int i = 0; i < subParts3d.Count; i++)
             {
                 BHG.ICurve bhc = subParts3d[i];
@@ -650,7 +652,7 @@ namespace BH.Engine.Rhinoceros
                     if (edge == null)
                     {
                         int crv = brep.Curves3D.Add(rhc);
-                        edge = brep.Edges.Add(startId, endId, crv, BH.oM.Geometry.Tolerance.Distance);
+                        edge = brep.Edges.Add(startId, endId, crv, rhinoTolerance);
                         rev3d = false;
                     }
 
@@ -659,7 +661,7 @@ namespace BH.Engine.Rhinoceros
                 else
                     rhTrim = brep.Trims.AddSingularTrim(brep.Vertices[startId], loop, Rhino.Geometry.IsoStatus.None, crv2d);
 
-                rhTrim.SetTolerances(BH.oM.Geometry.Tolerance.Distance, BH.oM.Geometry.Tolerance.Distance);
+                rhTrim.SetTolerances(rhinoTolerance, rhinoTolerance);
 
                 //TODO: In Rhino 6 this could be replaced with Surface.IsIsoParametric(Curve)
                 RHG.Point3d start = rhc2d.PointAtStart;
@@ -667,22 +669,22 @@ namespace BH.Engine.Rhinoceros
 
                 if (rhc2d.IsLinear())
                 {
-                    if (Math.Abs(start.X - end.X) <= BH.oM.Geometry.Tolerance.Distance)
+                    if (Math.Abs(start.X - end.X) <= rhinoTolerance)
                     {
                         RHG.Interval domainU = brep.Surfaces[face.SurfaceIndex].Domain(0);
-                        if (Math.Abs(start.X - domainU.Min) <= BH.oM.Geometry.Tolerance.Distance)
+                        if (Math.Abs(start.X - domainU.Min) <= rhinoTolerance)
                             rhTrim.IsoStatus = Rhino.Geometry.IsoStatus.West;
-                        else if (Math.Abs(start.X - domainU.Max) <= BH.oM.Geometry.Tolerance.Distance)
+                        else if (Math.Abs(start.X - domainU.Max) <= rhinoTolerance)
                             rhTrim.IsoStatus = RHG.IsoStatus.East;
                         else
                             rhTrim.IsoStatus = RHG.IsoStatus.X;
                     }
-                    else if (Math.Abs(start.Y - end.Y) <= BH.oM.Geometry.Tolerance.Distance)
+                    else if (Math.Abs(start.Y - end.Y) <= rhinoTolerance)
                     {
                         RHG.Interval domainV = brep.Surfaces[face.SurfaceIndex].Domain(1);
-                        if (Math.Abs(start.Y - domainV.Min) <= BH.oM.Geometry.Tolerance.Distance)
+                        if (Math.Abs(start.Y - domainV.Min) <= rhinoTolerance)
                             rhTrim.IsoStatus = Rhino.Geometry.IsoStatus.South;
-                        else if (Math.Abs(start.Y - domainV.Max) <= BH.oM.Geometry.Tolerance.Distance)
+                        else if (Math.Abs(start.Y - domainV.Max) <= rhinoTolerance)
                             rhTrim.IsoStatus = RHG.IsoStatus.North;
                         else
                             rhTrim.IsoStatus = RHG.IsoStatus.Y;

--- a/Rhinoceros_Engine/Query/DocumentTolerance.cs
+++ b/Rhinoceros_Engine/Query/DocumentTolerance.cs
@@ -38,8 +38,8 @@ namespace BH.Engine.Rhinoceros
                 return doc.ModelAbsoluteTolerance;
             else
             {
-                BH.Engine.Reflection.Compute.RecordError("Rhino document tolerance could not be retrieved because active document has not been found.");
-                return double.NaN;
+                BH.Engine.Reflection.Compute.RecordWarning("Rhino document tolerance could not be retrieved because active document has not been found - standard BHoM geometrical tolerance is returned instead.");
+                return BH.oM.Geometry.Tolerance.Distance;
             }
         }
 

--- a/Rhinoceros_Engine/Query/DocumentTolerance.cs
+++ b/Rhinoceros_Engine/Query/DocumentTolerance.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using Rhino;
+
+namespace BH.Engine.Rhinoceros
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static double DocumentTolerance()
+        {
+            RhinoDoc doc = Rhino.RhinoDoc.ActiveDoc;
+
+            if (doc != null)
+                return doc.ModelAbsoluteTolerance;
+            else
+            {
+                BH.Engine.Reflection.Compute.RecordError("Rhino document tolerance could not be retrieved because active document has not been found.");
+                return double.NaN;
+            }
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
+++ b/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
@@ -39,10 +39,10 @@ namespace BH.Engine.Rhinoceros
                 return (type != typeof(Extrusion)
                      && type != typeof(Pipe)
                      && type != typeof(Loft)
-                     //&& type != typeof(PolySurface)
                      && type != typeof(CompositeGeometry)
                      && type != typeof(Quaternion)
-                     && type != typeof(Basis));
+                     && type != typeof(Basis)
+                     && type != typeof(SurfaceTrim));
             else
                 return false;
         }

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -98,6 +98,7 @@
     <Compile Include="Create\Polyline.cs" />
     <Compile Include="Create\Vector3d.cs" />
     <Compile Include="Create\Vector3f.cs" />
+    <Compile Include="Query\DocumentTolerance.cs" />
     <Compile Include="Query\IsEqual.cs" />
     <Compile Include="Query\IsPlanarSurface.cs" />
     <Compile Include="Query\IsRhinoEquivalent.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #170

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[On SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRhinoceros%5FToolkit%2FRhinoceros%5FToolkit%2DIssue170%2DTrimmed%20surface%20does%20not%20convert%20to%20BHoMGeometry%20correctly)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- BHoM => Rhino BRep convert tolerance bug fixed
- `Query.DocumentTolerance` method added


### Additional comments
<!-- As required -->
Extra checks in `Query.DocumentTolerance` added to manage the case where the method is somehow called from outside of Rhino or there is no active document - better safe than sorry 😉 