### PR TITLE
Make FromRhino interface methods compliant to avoid stack overflow crash

### DIFF
--- a/Rhinoceros_Engine/Convert/FromRhino.cs
+++ b/Rhinoceros_Engine/Convert/FromRhino.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RHG = Rhino.Geometry;
 using BHG = BH.oM.Geometry;
+using BH.Engine.Reflection;
 
 namespace BH.Engine.Rhinoceros
 {
@@ -34,14 +35,21 @@ namespace BH.Engine.Rhinoceros
         /**** Public Methods  - Interfaces              ****/
         /***************************************************/
 
-        public static BHG.IGeometry FromRhino(this RHG.GeometryBase geometry)
+        public static BHG.IGeometry IFromRhino(this RHG.GeometryBase geometry)
         {
             return (geometry == null) ? null : Convert.FromRhino(geometry as dynamic);
         }
 
         /***************************************************/
 
-        public static BHG.IGeometry FromRhino<T>(this Rhino.IEpsilonComparable<T> geometry)
+        public static BHG.IGeometry IFromRhino<T>(this Rhino.IEpsilonComparable<T> geometry)
+        {
+            return (geometry == null) ? null : Convert.FromRhino(geometry as dynamic);
+        }
+
+        /***************************************************/
+
+        public static BHG.IGeometry IFromRhino(this object geometry)
         {
             return (geometry == null) ? null : Convert.FromRhino(geometry as dynamic);
         }
@@ -529,7 +537,7 @@ namespace BH.Engine.Rhinoceros
 
         public static BHG.CompositeGeometry FromRhino(this List<RHG.GeometryBase> geometries)
         {
-            return new BHG.CompositeGeometry { Elements = geometries.Select(x => x.FromRhino()).ToList() };
+            return new BHG.CompositeGeometry { Elements = geometries.Select(x => x.IFromRhino()).ToList() };
         }
 
         /***************************************************/
@@ -649,6 +657,19 @@ namespace BH.Engine.Rhinoceros
             }
             else
                 return curve.FromRhino();
+        }
+
+
+        /***************************************************/
+        /**** Fallback Methods                          ****/
+        /***************************************************/
+
+        public static BHG.IGeometry FromRhino(this object obj)
+        {
+            if (obj != null)
+                Engine.Reflection.Compute.RecordError($"No conversion could be found between {obj.GetType().IToText()} and Rhino geometry.");
+
+            return null;
         }
 
         /***************************************************/

--- a/Rhinoceros_Engine/Convert/FromRhino.cs
+++ b/Rhinoceros_Engine/Convert/FromRhino.cs
@@ -337,6 +337,13 @@ namespace BH.Engine.Rhinoceros
             return rPolyline.FromRhino();
         }
 
+        /***************************************************/
+
+        private static BHG.Polyline FromRhino(this RHG.Rectangle3d rectangle)
+        {
+            return FromRhino(rectangle.ToPolyline());
+        }
+
 
         /***************************************************/
         /**** Public Methods  - Surfaces                ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Needed for
https://github.com/BHoM/Grasshopper_Toolkit/pull/567

   
### Issues addressed by this PR

The FromRhino interface methods were not compliant (Not starting with `I`) therefore causing a stack overflow crash when a FromRhino method could not be found for a specific type


### Test files
See https://github.com/BHoM/Grasshopper_Toolkit/pull/567#pullrequestreview-533235943 for an example of crash scenario.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->