### PR TITLE
Remove error for extrusion convert

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -437,7 +437,6 @@ namespace BH.Engine.Rhinoceros
         public static RHG.Extrusion ToRhino(this BHG.Extrusion extrusion)
         {
             // TODO Rhino_Adapter conversion to Extrusion
-            Engine.Reflection.Compute.RecordError("The operation is not implemented");
             return null;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #180

<!-- Add short description of what has been fixed -->

As stated in the issue, the error from the extrusions now failing to convert has started to pop up in GH, which just leads to confusions.

Before, this was dispatched from happening by the IsRhinoEquivalent method, but that does not seem to be called any longer. Simply removing the error gives the previous behaviour.

### Test files
<!-- Link to test files to validate the proposed changes -->

Simply create an extrusion. Should not display an error message:

![image](https://user-images.githubusercontent.com/22005920/100466241-e8ae4d00-30d0-11eb-945a-a4123abefdb7.png)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->