### PR TITLE
Rhinoceros_Engine: add convert methods for Extrusion

### DIFF
--- a/Rhinoceros_Engine/Convert/FromRhino.cs
+++ b/Rhinoceros_Engine/Convert/FromRhino.cs
@@ -51,10 +51,6 @@ namespace BH.Engine.Rhinoceros
 
         public static BHG.IGeometry IFromRhino(this object geometry)
         {
-            // Code to force testing of Extrusion: first convert toRhino, then fromRhino.
-            if (geometry is BH.oM.Geometry.Extrusion)
-                return Convert.FromRhino((geometry as BH.oM.Geometry.Extrusion).ToRhino());
-
             return (geometry == null) ? null : Convert.FromRhino(geometry as dynamic);
         }
 
@@ -467,9 +463,11 @@ namespace BH.Engine.Rhinoceros
 
             List<BHG.Extrusion> extrs = new List<BHG.Extrusion>();
 
+            // Exploits the fact that GetWireframe returns first the "profile" curves of the extrusion.
             var profileCurves = extrusion.GetWireframe();
             for (int i = 0; i < extrusion.ProfileCount; i++)
             {
+
                 var profileConverted = profileCurves.ElementAt(i).FromRhino();
                 BHG.Extrusion extr = BH.Engine.Geometry.Create.Extrusion(profileConverted, extrVec, extrusion.IsCappedAtBottom && extrusion.IsCappedAtTop);
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -433,7 +433,7 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
-        public static RHG.GeometryBase ToRhino(this BHG.Extrusion extrusion)
+        public static Rhino.Geometry.Surface ToRhino(this BHG.Extrusion extrusion)
         {
             if (!extrusion.Curve.IIsPlanar())
             {
@@ -483,7 +483,13 @@ namespace BH.Engine.Rhinoceros
                 .PerformSweep(rail, planarCurve)
                 .Aggregate((b1, b2) => { b1.Join(b2, tolerance, true); return b1; });
 
-            return joinedSweep;
+            if (joinedSweep.IsSurface)
+                return joinedSweep.Surfaces[0];
+
+            BH.Engine.Reflection.Compute.RecordError("Could not convert this BHoM Extrusion to a Rhino Surface. The extrusion direction is not perpendicular to the base curve, and the base curve is too complex for a Sweep to return a valid Surface.");
+            
+
+            return null;
         }
 
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -215,7 +215,7 @@ namespace BH.Engine.Rhinoceros
                 return null;
 
             IEnumerable<RHG.Curve> parts = bPolyCurve.Curves.Select(x => x.IToRhino());
-            
+
             // Check if bPolycurve is made of disconnected segments
             if (RHG.Curve.JoinCurves(parts).Length > 1)
                 return null;
@@ -385,8 +385,8 @@ namespace BH.Engine.Rhinoceros
                 RHG.Brep brep = new RHG.Brep();
                 int srf = brep.AddSurface(rhSurface);
                 RHG.BrepFace face = brep.Faces.Add(srf);
-                
-                foreach(BHG.SurfaceTrim trim in surface.OuterTrims)
+
+                foreach (BHG.SurfaceTrim trim in surface.OuterTrims)
                 {
                     brep.AddBrepTrim(face, trim, RHG.BrepLoopType.Outer);
                 }
@@ -395,7 +395,7 @@ namespace BH.Engine.Rhinoceros
                 {
                     brep.AddBrepTrim(face, trim, RHG.BrepLoopType.Inner);
                 }
-                
+
                 return brep.IsValid ? brep : null;
             }
         }
@@ -433,9 +433,10 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
-        public static RHG.Extrusion ToRhino(this BHG.Extrusion extrusion)
+        public static RHG.GeometryBase ToRhino(this BHG.Extrusion extrusion)
         {
-            if (!extrusion.Curve.IIsPlanar()) {
+            if (!extrusion.Curve.IIsPlanar())
+            {
                 BH.Engine.Reflection.Compute.RecordError("The provided BHoM Extrusion has a base curve that is not planar.");
                 return null;
             }
@@ -445,17 +446,43 @@ namespace BH.Engine.Rhinoceros
             RHG.Plane curvePlane;
             planarCurve.TryGetPlane(out curvePlane);
 
+            double angle = RHG.Vector3d.VectorAngle(curvePlane.Normal, extrusion.Direction.ToRhino());
 
-            double extrHeight = extrusion.Direction.Length();
+            double tolerance = 0.001;
+            if (angle > tolerance || (2 * Math.PI - tolerance < angle && angle < 2 * Math.PI + tolerance))
+            {
+                // It can be represented by a Rhino extrusion (which enforces perpendicularity btw Curve plane and Vector)
 
-            double angle = RHG.Vector3d.VectorAngle(curvePlane.Normal, extrusion.Direction.ToRhino()) * (180 / Math.PI);
+                double extrHeight = extrusion.Direction.Length();
 
-            if (angle > 90)
-                extrHeight = -extrHeight; 
+                if (angle > Math.PI)
+                    extrHeight = -extrHeight;
 
-            RHG.Extrusion extr = Rhino.Geometry.Extrusion.Create(planarCurve, extrHeight, extrusion.Capped);
+                RHG.Extrusion extr = Rhino.Geometry.Extrusion.Create(planarCurve, extrHeight, extrusion.Capped);
 
-            return extr;
+                return extr;
+            }
+
+            // Otherwise, provide a Sweep to cover extrusion with a base curve that is not orthogonal to the extr direction
+
+            // Create a Line to be the sweep rail. Use centroid/mid-point of base curve as start point.
+            RHG.Point3d centrePoint;
+            if (planarCurve.IsClosed)
+            {
+                var areaProp = Rhino.Geometry.AreaMassProperties.Compute(planarCurve);
+                centrePoint = areaProp.Centroid;
+            }
+            else
+                centrePoint = planarCurve.PointAt(0.5);
+
+            RHG.Point3d endPoint = centrePoint + extrusion.Direction.ToRhino();
+            var rail = new RHG.Line(centrePoint, endPoint);
+
+            var joinedSweep = new RHG.SweepOneRail()
+                .PerformSweep(new RHG.LineCurve(rail), planarCurve)
+                .Aggregate((b1, b2) => { b1.Join(b2, tolerance, true); return b1; });
+
+            return joinedSweep;
         }
 
 
@@ -711,7 +738,7 @@ namespace BH.Engine.Rhinoceros
         }
 
         /***************************************************/
-        
+
         private static int AddVertex(this RHG.Brep brep, RHG.Point3d point)
         {
             int id = -1;
@@ -734,7 +761,7 @@ namespace BH.Engine.Rhinoceros
         }
 
         /***************************************************/
-        
+
         private static bool IsSameEdge(this RHG.Curve curve, RHG.BrepEdge edge)
         {
             double tolerance = BHG.Tolerance.Distance;

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -433,11 +433,29 @@ namespace BH.Engine.Rhinoceros
 
         /***************************************************/
 
-        [NotImplemented]
         public static RHG.Extrusion ToRhino(this BHG.Extrusion extrusion)
         {
-            // TODO Rhino_Adapter conversion to Extrusion
-            return null;
+            if (!extrusion.Curve.IIsPlanar()) {
+                BH.Engine.Reflection.Compute.RecordError("The provided BHoM Extrusion has a base curve that is not planar.");
+                return null;
+            }
+
+            var planarCurve = extrusion.Curve.IToRhino();
+
+            RHG.Plane curvePlane;
+            planarCurve.TryGetPlane(out curvePlane);
+
+
+            double extrHeight = extrusion.Direction.Length();
+
+            double angle = RHG.Vector3d.VectorAngle(curvePlane.Normal, extrusion.Direction.ToRhino()) * (180 / Math.PI);
+
+            if (angle > 90)
+                extrHeight = -extrHeight; 
+
+            RHG.Extrusion extr = Rhino.Geometry.Extrusion.Create(planarCurve, extrHeight, extrusion.Capped);
+
+            return extr;
         }
 
 

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -449,7 +449,8 @@ namespace BH.Engine.Rhinoceros
             double angle = RHG.Vector3d.VectorAngle(curvePlane.Normal, extrusion.Direction.ToRhino());
 
             double tolerance = 0.001;
-            if (angle > tolerance || (2 * Math.PI - tolerance < angle && angle < 2 * Math.PI + tolerance))
+
+            if (angle < tolerance || (2 * Math.PI - tolerance < angle && angle < 2 * Math.PI + tolerance))
             {
                 // It can be represented by a Rhino extrusion (which enforces perpendicularity btw Curve plane and Vector)
 
@@ -476,10 +477,10 @@ namespace BH.Engine.Rhinoceros
                 centrePoint = planarCurve.PointAt(0.5);
 
             RHG.Point3d endPoint = centrePoint + extrusion.Direction.ToRhino();
-            var rail = new RHG.Line(centrePoint, endPoint);
+            var rail = new RHG.LineCurve(centrePoint, endPoint);
 
             var joinedSweep = new RHG.SweepOneRail()
-                .PerformSweep(new RHG.LineCurve(rail), planarCurve)
+                .PerformSweep(rail, planarCurve)
                 .Aggregate((b1, b2) => { b1.Join(b2, tolerance, true); return b1; });
 
             return joinedSweep;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #182

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Create any BHoM Extrusion, then try to convert it ToRhino(), and then FromRhino().

To test the FromRhino() from a script, you may want to temporarily modify the IFromRhino method as below:
<details>

```cs
public static BHG.IGeometry IFromRhino(this object geometry)	     
{	 
            // Code to force testing of Extrusion: first convert toRhino, then fromRhino.	
            if (geometry is BH.oM.Geometry.Extrusion)	
                return Convert.FromRhino((geometry as BH.oM.Geometry.Extrusion).ToRhino());	

            return (geometry == null) ? null : Convert.FromRhino(geometry as dynamic);
}
```

</details>

otherwise, due to the Goo casting being enforced for BHoM components, you'll never be able to pass a Rhino object to FromRhino() using Grasshopper components.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->