### PR TITLE
Changing to using BHoM join instead of RhinoJoin when converting polycurves to avoid Rhino Crash

### DIFF
--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -274,7 +274,7 @@ namespace BH.Engine.Rhinoceros
 
             //Curve is checked that it is a joined curve and only converted if that is the case.
             //Appending disjoined curves to a single Rhino polycurves ensures it is joined and by doing so changes the geometry.
-            //Rhino Join is throwing access violation exceptions in some cases, leading to a full rhino crash, that can not be caught by a try-catch.
+            //Rhino Join is throwing access violation exceptions in some cases, leading to a full Rhino crash, that cannot be caught by a try-catch.
             //For this reason, the BHoM Join is used instead.
             if (BH.Engine.Geometry.Compute.IJoin(bPolyCurve.Curves).Count > 1)
                 return null;    //Not returning error message here as that will lead to confusing messages on any method returning a disjointed Polycurve deemed valid in BHoM.

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -272,10 +272,16 @@ namespace BH.Engine.Rhinoceros
             if (bPolyCurve == null)
                 return null;
 
+            //Curve is checked that it is a joined curve and only converted if that is the case.
+            //Appending disjoined curves to a single Rhino polycurves ensures it is joined and by doing so changes the geometry.
+            //Rhino Join is throwing access violation exceptions in some cases, leading to a full rhino crash, that can not be caught by a try-catch.
+            //For this reason, the BHoM Join is used instead.
+            if (BH.Engine.Geometry.Compute.IJoin(bPolyCurve.Curves).Count > 1)
+                return null;    //Not returning error message here as that will lead to confusing messages on any method returning a disjointed Polycurve deemed valid in BHoM.
+
             IEnumerable<RHG.Curve> parts = bPolyCurve.Curves.Select(x => x.IToRhino());
 
-            // Check if bPolycurve is made of disconnected segments
-            if (RHG.Curve.JoinCurves(parts).Length > 1)
+            if (parts.Any(x => x == null))
                 return null;
 
             RHG.PolyCurve rPolycurve = new RHG.PolyCurve();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #220

<!-- Add short description of what has been fixed -->

Using BHoM Join instead of Rhino join to check if the curve can be coverted.

This is to avoid full blown crashes of Rhino from happening that can for some cases be triggered by the Rhino.Join method that was used.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Rhinoceros_Toolkit/%23221-AvoidCallingRhinoJoinToStopRhinoCrashWhenConvertingPolycurves?csf=1&web=1&e=UMB25Z

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->