### PR TITLE
Changed namespace to .Adapters.Rhinoceros

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,0 @@
-
-https://github.com/BuroHappoldEngineering/BHoM_Documentation/wiki/How-do-I-add-new-code%3F

--- a/Rhinoceros_Engine/Compute/CaptureNamedViews.cs
+++ b/Rhinoceros_Engine/Compute/CaptureNamedViews.cs
@@ -30,10 +30,10 @@ using System.IO;
 using Rhino;
 using Rhino.Display;
 using System.Drawing;
-using BH.oM.Rhinoceros.ViewCapture;
+using BH.oM.Adapters.Rhinoceros.ViewCapture;
 using System.Drawing.Imaging;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Compute
     {

--- a/Rhinoceros_Engine/Compute/CaptureView.cs
+++ b/Rhinoceros_Engine/Compute/CaptureView.cs
@@ -30,10 +30,10 @@ using System.IO;
 using Rhino;
 using Rhino.Display;
 using System.Drawing;
-using BH.oM.Rhinoceros.ViewCapture;
+using BH.oM.Adapters.Rhinoceros.ViewCapture;
 using System.Drawing.Imaging;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Compute
     {

--- a/Rhinoceros_Engine/Compute/CollectAllModelData.cs
+++ b/Rhinoceros_Engine/Compute/CollectAllModelData.cs
@@ -31,7 +31,7 @@ using System.IO;
 using System.Drawing;
 using Rhino.Geometry;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Compute
     {

--- a/Rhinoceros_Engine/Compute/Geometry.cs
+++ b/Rhinoceros_Engine/Compute/Geometry.cs
@@ -22,7 +22,7 @@
 
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Compute
     {

--- a/Rhinoceros_Engine/Convert/FromRhino.cs
+++ b/Rhinoceros_Engine/Convert/FromRhino.cs
@@ -27,7 +27,7 @@ using RHG = Rhino.Geometry;
 using BHG = BH.oM.Geometry;
 using BH.Engine.Base;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Convert
     {

--- a/Rhinoceros_Engine/Convert/ToRhino.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino.cs
@@ -33,7 +33,7 @@ using Rhino.Display;
 using BH.oM.Graphics;
 using System.ComponentModel;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Convert
     {

--- a/Rhinoceros_Engine/Convert/ToRhino5.cs
+++ b/Rhinoceros_Engine/Convert/ToRhino5.cs
@@ -25,7 +25,7 @@ using RHG = Rhino.Geometry;
 using BHG = BH.oM.Geometry;
 using BH.Engine.Geometry;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Convert
     {

--- a/Rhinoceros_Engine/Create/Arc.cs
+++ b/Rhinoceros_Engine/Create/Arc.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/ArcCurve.cs
+++ b/Rhinoceros_Engine/Create/ArcCurve.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Circle.cs
+++ b/Rhinoceros_Engine/Create/Circle.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/ControlPoint.cs
+++ b/Rhinoceros_Engine/Create/ControlPoint.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Curve.cs
+++ b/Rhinoceros_Engine/Create/Curve.cs
@@ -24,7 +24,7 @@ using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Line.cs
+++ b/Rhinoceros_Engine/Create/Line.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/LineCurve.cs
+++ b/Rhinoceros_Engine/Create/LineCurve.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/NurbsCurve.cs
+++ b/Rhinoceros_Engine/Create/NurbsCurve.cs
@@ -24,7 +24,7 @@ using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Point3d.cs
+++ b/Rhinoceros_Engine/Create/Point3d.cs
@@ -24,7 +24,7 @@ using Rhino.Geometry;
 using System;
 using System.Collections.Generic;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Point3f.cs
+++ b/Rhinoceros_Engine/Create/Point3f.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/PolyCurve.cs
+++ b/Rhinoceros_Engine/Create/PolyCurve.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Polyline.cs
+++ b/Rhinoceros_Engine/Create/Polyline.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/PolylineCurve.cs
+++ b/Rhinoceros_Engine/Create/PolylineCurve.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Vector3d.cs
+++ b/Rhinoceros_Engine/Create/Vector3d.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Create/Vector3f.cs
+++ b/Rhinoceros_Engine/Create/Vector3f.cs
@@ -23,7 +23,7 @@
 using Rhino.Geometry;
 using System;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Create
     {

--- a/Rhinoceros_Engine/Query/DocumentTolerance.cs
+++ b/Rhinoceros_Engine/Query/DocumentTolerance.cs
@@ -22,7 +22,7 @@
 
 using Rhino;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Query
     {

--- a/Rhinoceros_Engine/Query/IsEqual.cs
+++ b/Rhinoceros_Engine/Query/IsEqual.cs
@@ -25,7 +25,7 @@ using RHG = Rhino.Geometry;
 using BHG = BH.oM.Geometry;
 using System.Collections.Generic;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Query
     {

--- a/Rhinoceros_Engine/Query/IsPlanarSurface.cs
+++ b/Rhinoceros_Engine/Query/IsPlanarSurface.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.Engine.Geometry;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Query
     {

--- a/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
+++ b/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace BH.Engine.Rhinoceros
+namespace BH.Engine.Adapters.Rhinoceros
 {
     public static partial class Query
     {

--- a/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
+++ b/Rhinoceros_Engine/Query/IsRhinoEquivalent.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.Adapters.Rhinoceros
         /**** Public Methods  - Mesh                    ****/
         /***************************************************/
 
-        public static bool IsRhinoEquivalent(Type type)     
+        public static bool IsRhinoEquivalent(this Type type)     
         {
             if (typeof(IGeometry).IsAssignableFrom(type))
                 return (type != typeof(Extrusion)

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{93CEDC69-F9C0-4E08-9E94-07F120D811DC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.Engine.Rhinoceros</RootNamespace>
+    <RootNamespace>BH.Engine.Adapters.Rhinoceros</RootNamespace>
     <AssemblyName>Rhinoceros_Engine</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -115,6 +115,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Versioning71.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rhinoceros_oM\Rhinoceros_oM.csproj">

--- a/Rhinoceros_Engine/Rhinoceros_Engine.csproj
+++ b/Rhinoceros_Engine/Rhinoceros_Engine.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,35 +34,35 @@
   <ItemGroup>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Dimensional_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eto, Version=2.5.0.0, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
       <HintPath>..\packages\RhinoCommon.6.33.20343.16431\lib\net45\Eto.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Geometry_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Graphics_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Graphics_oM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Graphics_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Rhino.UI, Version=6.33.20343.16430, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">

--- a/Rhinoceros_Engine/Versioning71.json
+++ b/Rhinoceros_Engine/Versioning71.json
@@ -1,10 +1,10 @@
 ﻿{
   "Namespace": {
     "ToNew": {
-      "BH.oM.Rhinoceros": "BH.oM.Adapters.Rhinoceros"
+      "BH.Engine.Rhinoceros": "BH.Engine.Adapters.Rhinoceros"
     },
     "ToOld": {
-      "BH.oM.Adapters.Rhinoceros": "BH.oM.Rhinoceros"
+      "BH.Engine.Adapters.Rhinoceros": "BH.Engine.Rhinoceros"
     }
   }
 }

--- a/Rhinoceros_Engine/Versioning71.json
+++ b/Rhinoceros_Engine/Versioning71.json
@@ -1,0 +1,10 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+      "BH.oM.Rhinoceros": "BH.oM.Adapters.Rhinoceros"
+    },
+    "ToOld": {
+      "BH.oM.Adapters.Rhinoceros": "BH.oM.Rhinoceros"
+    }
+  }
+}

--- a/Rhinoceros_oM/Rhinoceros_oM.csproj
+++ b/Rhinoceros_oM/Rhinoceros_oM.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,7 +34,7 @@
   <ItemGroup>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/Rhinoceros_oM/Rhinoceros_oM.csproj
+++ b/Rhinoceros_oM/Rhinoceros_oM.csproj
@@ -53,6 +53,9 @@
     <Compile Include="ViewCapture\ScaleViewCaptureSettings.cs" />
     <Compile Include="ViewCapture\IViewCaptureSettings.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Versioning71.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\\ProgramData\\BHoM\\Assemblies" /Y</PostBuildEvent>

--- a/Rhinoceros_oM/Versioning71.json
+++ b/Rhinoceros_oM/Versioning71.json
@@ -1,0 +1,10 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+      "BH.oM.Rhinoceros": "BH.oM.Adapters.Rhinoceros"
+    },
+    "ToOld": {
+      "BH.oM.Adapters.Rhinoceros": "BH.oM.Rhinoceros"
+    }
+  }
+}

--- a/Rhinoceros_oM/ViewCapture/DimensionViewCaptureSettings.cs
+++ b/Rhinoceros_oM/ViewCapture/DimensionViewCaptureSettings.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using System.ComponentModel;
 
-namespace BH.oM.Rhinoceros.ViewCapture
+namespace BH.oM.Adapters.Rhinoceros.ViewCapture
 {
     [Description("View capture settings class with control over the final size of the image in pixels.")]
     public class DimensionViewCaptureSettings : IViewCaptureSettings

--- a/Rhinoceros_oM/ViewCapture/IViewCaptureSettings.cs
+++ b/Rhinoceros_oM/ViewCapture/IViewCaptureSettings.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using System.ComponentModel;
 
-namespace BH.oM.Rhinoceros.ViewCapture
+namespace BH.oM.Adapters.Rhinoceros.ViewCapture
 {
     [Description("Base itnerface for interface controling settings for view capture.")]
     public interface IViewCaptureSettings : IObject

--- a/Rhinoceros_oM/ViewCapture/ScaleViewCaptureSettings.cs
+++ b/Rhinoceros_oM/ViewCapture/ScaleViewCaptureSettings.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using System.ComponentModel;
 
-namespace BH.oM.Rhinoceros.ViewCapture
+namespace BH.oM.Adapters.Rhinoceros.ViewCapture
 {
     [Description("View capture settings allowing the size of the image to be controled as a scale of the current viewport size.")]
     public class ScaleViewCaptureSettings : IViewCaptureSettings


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #62 

<!-- Add short description of what has been fixed -->
Changed following namespaces: 
- `BH.oM.Rhinoceros => BH.oM.Adapters.Rhinoceros`
- `BH.Engine.Rhinoceros => BH.Engine.Adapters.Rhinoceros`
